### PR TITLE
Set sameSite cookie flag to none

### DIFF
--- a/website/src/routes/(auth)/login/+page.server.ts
+++ b/website/src/routes/(auth)/login/+page.server.ts
@@ -57,7 +57,7 @@ export const actions: Actions = {
                 path: '/',
                 httpOnly: true,
                 secure: process.env.NODE_ENV === 'production',
-                sameSite: 'strict',
+                sameSite: 'none',
                 maxAge: 60 * 60 * 24 * 7
             });
 


### PR DESCRIPTION
Set the sameSite cookie flag to none so that 3rd party clients can login and get tokens