### PR TITLE
Remove IQ test on emails from other domains

### DIFF
--- a/SHARP/README.md
+++ b/SHARP/README.md
@@ -4,7 +4,7 @@ This server implements the SHARP protocol, a decentralized email system that use
 
 ## Protocol Details
 
-* **Version:** SHARP/1.0
+* **Version:** SHARP/1.1
 * **Transport:** TCP with JSON messages
 * **Default Ports:** 5000 (SHARP), 5001 (HTTP API)
 
@@ -13,9 +13,9 @@ This server implements the SHARP protocol, a decentralized email system that use
 1. **Connection Establishment**
    ```json
    // Client -> Server
-   { "type": "HELLO", "server_id": "sender#domain.com", "protocol": "SHARP/1.0" }
+   { "type": "HELLO", "server_id": "sender#domain.com", "protocol": "SHARP/1.1" }
    // Server -> Client
-   { "type": "OK", "protocol": "SHARP/1.0" }
+   { "type": "OK", "protocol": "SHARP/1.1" }
    ```
 
 2. **Mail Delivery**
@@ -176,7 +176,7 @@ SHARP uses addresses in the format `user#domain.com`.
 Besides configuration available through the `.env` file, some core protocol and behavior settings are defined as constants in `SHARP/main.js`:
 
 ```javascript
-const PROTOCOL_VERSION = 'SHARP/1.0'
+const PROTOCOL_VERSION = 'SHARP/1.1'
 
 const KEYWORDS = {
     promotions: new Set([/* ...keywords... */]),

--- a/SHARP/main.js
+++ b/SHARP/main.js
@@ -166,8 +166,6 @@ async function handleSharpMessage(socket, raw, state) {
                     if (cmd.content_type === 'text/plain' && cmd.body) {
                         const from = parseSharpAddress(state.from);
                         return;
-                        // Why were we checking data for other servers on our own DB :sob: :pray:
-                        // on next SHARP version we can embed IQ data on the email. And also fix mail spoofing :3
                         }
                     }
 

--- a/SHARP/main.js
+++ b/SHARP/main.js
@@ -165,17 +165,9 @@ async function handleSharpMessage(socket, raw, state) {
                 if (cmd.type === 'EMAIL_CONTENT') {
                     if (cmd.content_type === 'text/plain' && cmd.body) {
                         const from = parseSharpAddress(state.from);
-                        try {
-                            const users = await sql`SELECT iq FROM users WHERE username = ${from.username}`;
-                            const userIQ = users[0]?.iq;
-                            const { isValid, limit } = checkVocabulary(cmd.body, userIQ);
-                            if (!isValid) {
-                                sendError(socket, `Message contains words longer than the allowed ${limit} characters for your IQ level (${userIQ}). Please simplify.`);
-                                return;
-                            }
-                        } catch (dbError) {
-                            console.error("Error checking vocabulary:", dbError);
-                            // Continue without vocabulary check if DB error
+                        return 
+                        // Why were we checking data for other servers on our own DB :sob: :pray:
+                        // on next SHARP version we can embed IQ data on the email. And also fix mail spoofing :3
                         }
                     }
 

--- a/SHARP/main.js
+++ b/SHARP/main.js
@@ -165,7 +165,7 @@ async function handleSharpMessage(socket, raw, state) {
                 if (cmd.type === 'EMAIL_CONTENT') {
                     if (cmd.content_type === 'text/plain' && cmd.body) {
                         const from = parseSharpAddress(state.from);
-                        return 
+                        return;
                         // Why were we checking data for other servers on our own DB :sob: :pray:
                         // on next SHARP version we can embed IQ data on the email. And also fix mail spoofing :3
                         }


### PR DESCRIPTION
When an email was sent from a diff domain it was being handled wrong
sakura#outpoot.com -> face#twoblade.com
The IQ would be from sakura#twoblade.com, if it didn't exist it would be null and would default to 3 char words. 