### PR TITLE
Fix homepage link in README.md (vyntr.com —> twoblade.com)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img style="width: 128px; height: 128px" src="website/static/logo.svg" /><h1 style="font-size: 48px"><a href="https://vyntr.com">Twoblade.com</a> - an email protocol & client</h1>
+<img style="width: 128px; height: 128px" src="website/static/logo.svg" /><h1 style="font-size: 48px"><a href="https://twoblade.com">Twoblade.com</a> - an email protocol & client</h1>
 [Privacy Policy](https://twoblade.com/legal/privacy) | [Terms of Service](https://twoblade.com/legal/terms) | [License](LICENSE) | [YouTube video](https://twoblade.com)
 
 **Twoblade.com** is an interface for **SHARP** (**S**elf-**H**osted **A**ddress **R**outing **P**rotocol) - a decentralized email system that uses the `#` symbol for addressing (e.g., `user#domain.com`).


### PR DESCRIPTION
README linked to vyntr.com instead of twoblade.com.
Simply knowing this is annoying. (Not sure if it was intentional.)