### PR TITLE
Fix $MODERATION_DIR path

### DIFF
--- a/SHARP/database/init.sh
+++ b/SHARP/database/init.sh
@@ -22,7 +22,7 @@ echo "Created .env"
 echo "NOTE: Replace JWT_SECRET with a secure value (use 'openssl rand -hex 64'). IT MUST MATCH ../website/.env"
 echo "NOTE: In production, replace Turnstile key with your actual key from Cloudflare"
 
-MODERATION_DIR="../../website/websocket/src"
+MODERATION_DIR="../website/websocket/src"
 mkdir -p "$MODERATION_DIR"
 cat > "$MODERATION_DIR/moderation.ts" << EOF
 // Moderation service for websocket connections


### PR DESCRIPTION
Changed the path in init.sh so executing the init.sh script in the SHARP directory actually places the moderation.ts file into the correct directory.

Also, looks like githubs webeditor deleted the newline at the end- can re-add it if that's problematic.