### PR TITLE
Easier docker setup, less intervention 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,44 @@
+## If you don't use docker:
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+
+## If you do use docker use above and below:
+
+# If you are using the docker compose file, it needs to be the same as the postgres hostname
+POSTGRES_HOST=postgres
+POSTGRES_PORT=5432
+POSTGRES_DATABASE=postgres
+# You should change this before first boot
+
+# Enter your domain name
+DOMAIN_NAME=localhost
+# Enter your public URL that points towards the websocket
+PUBLIC_WEBSOCKET_URL=http://localhost:3001
+
+SHARP_PORT=5000
+SHARP_HTTP_PORT=5001
+
+# The JWT secret should be long, random and similar to a password. Do not share it with anyone.
+# Run `openssl rand -hex 64` to generate one
+# Used for authentication
+JWT_SECRET=REPLACE_ME_WITH_RANDOM_STRING
+
+# S3-compatible works too.
+PRIVATE_B2_KEY_ID=KEY_ID
+PRIVATE_B2_APP_KEY=APP_KEY
+PRIVATE_B2_BUCKET=BUCKET
+PRIVATE_B2_REGION=us-west-001
+PRIVATE_B2_ENDPOINT=http://s3.example.com
+
+# A cookie from the website, optional & used in /test
+TEST_AUTH_TOKEN=
+
+# Comes from docker-compose
+REDIS_URL=redis://redis:6379
+
+# Cloudflare Turnstile keys, these are for testing & will validate any req. Replace with actual ones in prod.
+PUBLIC_TURNSTILE_SITE_KEY=1x00000000000000000000AA
+
+# Optional but required for Turnstile spam prevention in production
+# These are the test keys that will accept any token
+PRIVATE_TURNSTILE_SECRET_KEY=1x0000000000000000000000000000000AA

--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,8 @@
-## If you don't use docker:
+## If you don't use docker-compose:
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
 
-## If you do use docker use above and below:
+## If you do use docker-compose use above and below:
 
 # If you are using the docker compose file, it needs to be the same as the postgres hostname
 POSTGRES_HOST=postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,26 @@
-version: '3.8'
 services:
   app:
     build:
       context: .
       target: production-main
       dockerfile: website/Dockerfile
+      args:
+        - PUBLIC_DOMAIN=${DOMAIN_NAME:?Missing required value for DOMAIN_NAME in .env}
+        - PUBLIC_WEBSOCKET_URL=${PUBLIC_WEBSOCKET_URL:?Missing required value for PUBLIC_WEBSOCKET_URL in .env}
+        - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@${POSTGRES_HOST:-localhost}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-postgres}
+        - JWT_SECRET=${JWT_SECRET:-REPLACE_ME_WITH_RANDOM_STRING}
+        - PRIVATE_B2_KEY_ID=${PRIVATE_B2_KEY_ID:?Missing required value for PRIVATE_B2_KEY_ID in .env}
+        - PRIVATE_B2_APP_KEY=${PRIVATE_B2_APP_KEY:?Missing required value for PRIVATE_B2_APP_KEY in .env}
+        - PRIVATE_B2_BUCKET=${PRIVATE_B2_BUCKET:?Missing required value for PRIVATE_B2_BUCKET in .env}
+        - PRIVATE_B2_REGION=${PRIVATE_B2_REGION:?Missing required value for PRIVATE_B2_REGION in .env}
+        - PRIVATE_B2_ENDPOINT=${PRIVATE_B2_ENDPOINT:?Missing required value for PRIVATE_B2_ENDPOINT in .env}
+        - TEST_AUTH_TOKEN=${TEST_AUTH_TOKEN}
+        - REDIS_URL=${REDIS_URL:-redis://redis:6379}
+        - PUBLIC_TURNSTILE_SITE_KEY=${PUBLIC_TURNSTILE_SITE_KEY:-1x00000000000000000000AA}
+    networks:
+      - twoblade
     ports:
       - "3002:3000"
-    env_file:
-      - website/.env
     depends_on:
       - websocket
       - redis
@@ -18,39 +30,68 @@ services:
       context: .
       target: production-websocket
       dockerfile: website/Dockerfile
+    networks:
+      - twoblade
     ports:
       - "8081:8080"
-    env_file:
-      - website/.env
-
+    environment:
+      - PUBLIC_DOMAIN=${DOMAIN_NAME:?Missing required value for DOMAIN_NAME in .env}
+      - PUBLIC_WEBSOCKET_URL=${PUBLIC_WEBSOCKET_URL:?Missing required value for PUBLIC_WEBSOCKET_URL in .env}
+      - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@${POSTGRES_HOST:-localhost}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-postgres}
+      - JWT_SECRET=${JWT_SECRET:-REPLACE_ME_WITH_RANDOM_STRING}
+      - PRIVATE_B2_KEY_ID=${PRIVATE_B2_KEY_ID:?Missing required value for PRIVATE_B2_KEY_ID in .env}
+      - PRIVATE_B2_APP_KEY=${PRIVATE_B2_APP_KEY:?Missing required value for PRIVATE_B2_APP_KEY in .env}
+      - PRIVATE_B2_BUCKET=${PRIVATE_B2_BUCKET:?Missing required value for PRIVATE_B2_BUCKET in .env}
+      - PRIVATE_B2_REGION=${PRIVATE_B2_REGION:?Missing required value for PRIVATE_B2_REGION in .env}
+      - PRIVATE_B2_ENDPOINT=${PRIVATE_B2_ENDPOINT:?Missing required value for PRIVATE_B2_ENDPOINT in .env}
+      - TEST_AUTH_TOKEN=${TEST_AUTH_TOKEN}
+      - REDIS_URL=${REDIS_URL:-redis://redis:6379}
+      - PUBLIC_TURNSTILE_SITE_KEY=${PUBLIC_TURNSTILE_SITE_KEY:-1x00000000000000000000AA}
   sharp:
     build:
       context: .
       dockerfile: SHARP/Dockerfile
+    networks:
+      - twoblade
     ports:
-      - "5000:5000"
-      - "5001:5001"
-    env_file:
-      - SHARP/.env
+      - "5000:${SHARP_PORT:-5000}"
+      - "5001:${SHARP_HTTP_PORT:-5001}"
+    environment:
+      - DOMAIN_NAME=${DOMAIN_NAME:?Missing your domain name in .env}
+      - SHARP_PORT=${SHARP_PORT:-5000}
+      - HTTP_PORT=${SHARP_HTTP_PORT:-5001}
+      - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@${POSTGRES_HOST:-localhost}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-postgres}
+      - PRIVATE_TURNSTILE_SECRET_KEY=${PRIVATE_TURNSTILE_SECRET_KEY:-1x0000000000000000000000000000000AA}
+      - JWT_SECRET=${JWT_SECRET:-REPLACE_ME_WITH_RANDOM_STRING}
 
   redis:
     image: redis:8-alpine
+    hostname: redis
+    networks:
+      - twoblade
     volumes:
       - sharp_redisdata:/data
     command: "redis-server --save 60 1"
 
   postgres:
     image: pgvector/pgvector:pg16
-    container_name: postgres-db
+    hostname: postgres
     environment:
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
     ports:
       - "5432:5432"
+    networks:
+      - twoblade
     volumes:
       - pgdata:/var/lib/postgresql/data
       - ./SHARP/database/init.sql:/docker-entrypoint-initdb.d/init.sql
     restart: unless-stopped
+
+networks:
+  twoblade:
+    name: twoblade
+    driver: bridge
 
 volumes:
   pgdata:

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -7,6 +7,19 @@ ENV NODE_ENV="production"
 
 FROM base-node AS build-main
 
+ARG PUBLIC_DOMAIN
+ARG PUBLIC_WEBSOCKET_URL
+ARG DATABASE_URL
+ARG JWT_SECRET
+ARG PRIVATE_B2_KEY_ID
+ARG PRIVATE_B2_APP_KEY
+ARG PRIVATE_B2_BUCKET
+ARG PRIVATE_B2_REGION
+ARG PRIVATE_B2_ENDPOINT
+ARG TEST_AUTH_TOKEN
+ARG REDIS_URL
+ARG PUBLIC_TURNSTILE_SITE_KEY
+
 RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y \
     build-essential \
@@ -19,6 +32,16 @@ COPY website/package.json website/package-lock.json* ./
 
 RUN npm ci --include=dev
 
+RUN mkdir -p "./websocket/src" && cat >"./websocket/src/moderation.ts" <<EOF
+// Moderation service for websocket connections
+// Created by Dockerfile
+
+export function checkHardcore(msg: string): boolean {
+    // Placeholder implementation - should be replaced with actual detection
+    return false;
+}
+EOF
+
 COPY website/. ./
 
 RUN npm run build
@@ -27,6 +50,16 @@ RUN npm prune --omit=dev
 
 FROM base-node AS build-websocket
 WORKDIR /app/websocket
+
+RUN mkdir -p "/app/websocket/src" && cat >"/app/websocket/src/moderation.ts" <<EOF
+// Moderation service for websocket connections
+// Created by Dockerfile
+
+export function checkHardcore(msg: string): boolean {
+    // Placeholder implementation - should be replaced with actual detection
+    return false;
+}
+EOF
 
 COPY website/websocket/package.json ./
 COPY website/websocket/tsconfig.json ./


### PR DESCRIPTION
After trying it out I found some ways to improve the docker setup.

I haven't updated the README yet since their might be change requests.

In this setup you only need to:
- Copy the `.env.example` file to a `.env` file
- Change the values to match your stuff
- Run `docker compose build`
- Run `docker compose up -d`

And that would be it.

This also fixes the missing `moderation.ts` for docker builds, building non-docker still works with the old method.
I did also notice that the SHARP service might not boot correctly if the database hasn't initialised yet, especially if it has yet to import the `init.sql` but after a restart of the SHARP service it seems to be fixed and working as intended.